### PR TITLE
Added Conversation History API Endpoint

### DIFF
--- a/src/ai/design/design-workflow.ts
+++ b/src/ai/design/design-workflow.ts
@@ -717,24 +717,23 @@ async function _processMessage(
     ...config,
     streamMode: "values",
   })) {
+    // Get the last message which should be the AI's response
+    const msg = messages[messages?.length - 1];
+
+    // Always process AI messages to capture the response content
+    if (msg?.content && msg instanceof AIMessage) {
+      aiResponse = msg.content
+        .toString()
+        .replace(/<game_title>.*?<\/game_title>\n?/g, "");
+    }
+
     // Track if we've generated a specification
     if (specRequested) {
       if (currentGameSpec && currentGameSpec.designSpecification.length > 0) {
         updatedSpec = currentGameSpec;
-      } else {
-        aiResponse = "No spec received.";
       }
-      continue;
-    }
-
-    // Get the last message which should be the AI's response
-    const msg = messages[messages?.length - 1];
-
-    // Only process AI messages if we haven't generated a spec
-    if (!specRequested && msg?.content && msg instanceof AIMessage) {
-      aiResponse = msg.content
-        .toString()
-        .replace(/<game_title>.*?<\/game_title>\n?/g, "");
+      // Note: Don't set aiResponse to "No spec received." here since we want to preserve
+      // the actual AI response content even if spec generation fails
     }
 
     if (title) {

--- a/src/api/design/handler.ts
+++ b/src/api/design/handler.ts
@@ -1,4 +1,4 @@
-import { FastifyRequest, FastifyReply } from 'fastify';
+import { FastifyRequest, FastifyReply } from "fastify";
 import {
   ContinueDesignConversationRequest,
   ContinueDesignConversationRequestSchema,
@@ -9,29 +9,39 @@ import {
   GetFullSpecificationRequest,
   GetFullSpecificationRequestSchema,
   GetFullSpecificationResponse,
-} from '#chaincraft/api/design/schemas.js';
+  GetConversationHistoryRequest,
+  GetConversationHistoryRequestSchema,
+  GetConversationHistoryResponse,
+} from "#chaincraft/api/design/schemas.js";
 import {
   continueDesignConversation,
   generateImage,
   getFullDesignSpecification,
+  getConversationHistory,
   isActiveConversation,
-} from '#chaincraft/ai/design/design-workflow.js';
+} from "#chaincraft/ai/design/design-workflow.js";
 
 export async function handleContinueDesignConversation(
   request: FastifyRequest<{ Body: ContinueDesignConversationRequest }>,
   reply: FastifyReply
 ): Promise<ContinueDesignConversationResponse> {
-  const result = ContinueDesignConversationRequestSchema.safeParse(request.body);
-  
+  const result = ContinueDesignConversationRequestSchema.safeParse(
+    request.body
+  );
+
   if (!result.success) {
-    reply.code(400).send({ error: 'Invalid request', details: result.error });
+    reply.code(400).send({ error: "Invalid request", details: result.error });
     return Promise.reject();
   }
 
   try {
     const { conversationId, userMessage, gameDescription } = result.data;
-    const response = await continueDesignConversation(conversationId, userMessage, gameDescription);
-    
+    const response = await continueDesignConversation(
+      conversationId,
+      userMessage,
+      gameDescription
+    );
+
     return {
       designResponse: response.designResponse,
       updatedTitle: response.updatedTitle,
@@ -39,8 +49,8 @@ export async function handleContinueDesignConversation(
       specification: response.specification,
     };
   } catch (error) {
-    console.error('Error in continueDesignConversation:', error);
-    reply.code(500).send({ error: 'Internal server error' });
+    console.error("Error in continueDesignConversation:", error);
+    reply.code(500).send({ error: "Internal server error" });
     return Promise.reject();
   }
 }
@@ -50,22 +60,22 @@ export async function handleGenerateImage(
   reply: FastifyReply
 ): Promise<GenerateImageResponse> {
   const result = GenerateImageRequestSchema.safeParse(request.body);
-  
+
   if (!result.success) {
-    reply.code(400).send({ error: 'Invalid request', details: result.error });
+    reply.code(400).send({ error: "Invalid request", details: result.error });
     return Promise.reject();
   }
 
   try {
     const { conversationId } = result.data;
     const imageUrl = await generateImage(conversationId);
-    
+
     return {
       imageUrl,
     };
   } catch (error) {
-    console.error('Error in generateImage:', error);
-    reply.code(500).send({ error: 'Internal server error' });
+    console.error("Error in generateImage:", error);
+    reply.code(500).send({ error: "Internal server error" });
     return Promise.reject();
   }
 }
@@ -75,21 +85,21 @@ export async function handleGetFullSpecification(
   reply: FastifyReply
 ): Promise<GetFullSpecificationResponse> {
   const result = GetFullSpecificationRequestSchema.safeParse(request.body);
-  
+
   if (!result.success) {
-    reply.code(400).send({ error: 'Invalid request', details: result.error });
+    reply.code(400).send({ error: "Invalid request", details: result.error });
     return Promise.reject();
   }
 
   try {
     const { conversationId } = result.data;
     const specification = await getFullDesignSpecification(conversationId);
-    
+
     if (!specification) {
-      reply.code(404).send({ error: 'Specification not found' });
+      reply.code(404).send({ error: "Specification not found" });
       return Promise.reject();
     }
-    
+
     return {
       title: specification.title,
       summary: specification.summary,
@@ -97,9 +107,36 @@ export async function handleGetFullSpecification(
       designSpecification: specification.designSpecification,
     };
   } catch (error) {
-    console.error('Error in getFullSpecification:', error);
-    reply.code(500).send({ error: 'Internal server error' });
+    console.error("Error in getFullSpecification:", error);
+    reply.code(500).send({ error: "Internal server error" });
     return Promise.reject();
   }
 }
 
+export async function handleGetConversationHistory(
+  request: FastifyRequest<{ Body: GetConversationHistoryRequest }>,
+  reply: FastifyReply
+): Promise<GetConversationHistoryResponse> {
+  const result = GetConversationHistoryRequestSchema.safeParse(request.body);
+
+  if (!result.success) {
+    reply.code(400).send({ error: "Invalid request", details: result.error });
+    return Promise.reject();
+  }
+
+  try {
+    const { conversationId } = result.data;
+    const history = await getConversationHistory(conversationId);
+
+    return history;
+  } catch (error) {
+    console.error("Error in getConversationHistory:", error);
+
+    if (error instanceof Error && error.message.includes("not found")) {
+      reply.code(404).send({ error: "Conversation not found" });
+    } else {
+      reply.code(500).send({ error: "Internal server error" });
+    }
+    return Promise.reject();
+  }
+}

--- a/src/api/design/handler.ts
+++ b/src/api/design/handler.ts
@@ -12,11 +12,15 @@ import {
   GetConversationHistoryRequest,
   GetConversationHistoryRequestSchema,
   GetConversationHistoryResponse,
+  GetConversationMetadataRequest,
+  GetConversationMetadataRequestSchema,
+  GetConversationMetadataResponse,
 } from "#chaincraft/api/design/schemas.js";
 import {
   continueDesignConversation,
   generateImage,
   getFullDesignSpecification,
+  getCachedConversationMetadata,
   getConversationHistory,
   isActiveConversation,
 } from "#chaincraft/ai/design/design-workflow.js";
@@ -137,6 +141,38 @@ export async function handleGetConversationHistory(
     } else {
       reply.code(500).send({ error: "Internal server error" });
     }
+    return Promise.reject();
+  }
+}
+
+export async function handleGetConversationMetadata(
+  request: FastifyRequest<{ Body: GetConversationMetadataRequest }>,
+  reply: FastifyReply
+): Promise<GetConversationMetadataResponse> {
+  const result = GetConversationMetadataRequestSchema.safeParse(request.body);
+
+  if (!result.success) {
+    reply.code(400).send({ error: "Invalid request", details: result.error });
+    return Promise.reject();
+  }
+
+  try {
+    const { conversationId } = result.data;
+
+    // Get cached metadata (doesn't create checkpoints)
+    const metadata = await getCachedConversationMetadata(conversationId);
+
+    if (!metadata) {
+      reply.code(404).send({ error: "Conversation metadata not found" });
+      return Promise.reject();
+    }
+
+    return {
+      title: metadata.title,
+    };
+  } catch (error) {
+    console.error("Error in getConversationMetadata:", error);
+    reply.code(500).send({ error: "Internal server error" });
     return Promise.reject();
   }
 }

--- a/src/api/design/routes.ts
+++ b/src/api/design/routes.ts
@@ -5,6 +5,7 @@ import {
   handleGetFullSpecification,
   handleGetConversationHistory,
   handleGetConversationMetadata,
+  handlePublishGame,
 } from "./handler.js";
 import {
   ContinueDesignConversationRequestSchema,
@@ -17,6 +18,8 @@ import {
   GetConversationHistoryResponseSchema,
   GetConversationMetadataRequestSchema,
   GetConversationMetadataResponseSchema,
+  PublishGameRequestSchema,
+  PublishGameResponseSchema,
 } from "#chaincraft/api/design/schemas.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
@@ -101,5 +104,16 @@ export async function registerDesignRoutes(server: FastifyInstance) {
       },
     },
     handler: handleGetConversationMetadata,
+  });
+
+  // Publish game to IPFS
+  server.post("/publish", {
+    schema: {
+      body: zodToJsonSchema(PublishGameRequestSchema, "publishGameRequest"),
+      response: {
+        200: zodToJsonSchema(PublishGameResponseSchema, "publishGameResponse"),
+      },
+    },
+    handler: handlePublishGame,
   });
 }

--- a/src/api/design/routes.ts
+++ b/src/api/design/routes.ts
@@ -4,6 +4,7 @@ import {
   handleGenerateImage,
   handleGetFullSpecification,
   handleGetConversationHistory,
+  handleGetConversationMetadata,
 } from "./handler.js";
 import {
   ContinueDesignConversationRequestSchema,
@@ -14,6 +15,8 @@ import {
   GetFullSpecificationResponseSchema,
   GetConversationHistoryRequestSchema,
   GetConversationHistoryResponseSchema,
+  GetConversationMetadataRequestSchema,
+  GetConversationMetadataResponseSchema,
 } from "#chaincraft/api/design/schemas.js";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
@@ -81,5 +84,22 @@ export async function registerDesignRoutes(server: FastifyInstance) {
       },
     },
     handler: handleGetConversationHistory,
+  });
+
+  // Get conversation metadata (title, etc.) without creating checkpoints
+  server.post("/conversation/metadata", {
+    schema: {
+      body: zodToJsonSchema(
+        GetConversationMetadataRequestSchema,
+        "getConversationMetadataRequest"
+      ),
+      response: {
+        200: zodToJsonSchema(
+          GetConversationMetadataResponseSchema,
+          "getConversationMetadataResponse"
+        ),
+      },
+    },
+    handler: handleGetConversationMetadata,
   });
 }

--- a/src/api/design/routes.ts
+++ b/src/api/design/routes.ts
@@ -1,9 +1,10 @@
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance } from "fastify";
 import {
   handleContinueDesignConversation,
   handleGenerateImage,
   handleGetFullSpecification,
-} from './handler.js';
+  handleGetConversationHistory,
+} from "./handler.js";
 import {
   ContinueDesignConversationRequestSchema,
   ContinueDesignConversationResponseSchema,
@@ -11,40 +12,74 @@ import {
   GenerateImageResponseSchema,
   GetFullSpecificationRequestSchema,
   GetFullSpecificationResponseSchema,
-} from '#chaincraft/api/design/schemas.js';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+  GetConversationHistoryRequestSchema,
+  GetConversationHistoryResponseSchema,
+} from "#chaincraft/api/design/schemas.js";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export async function registerDesignRoutes(server: FastifyInstance) {
   // Continue design conversation
-  server.post('/conversation/continue', {
+  server.post("/conversation/continue", {
     schema: {
-      body: zodToJsonSchema(ContinueDesignConversationRequestSchema, 'continueDesignConversationRequest'),
+      body: zodToJsonSchema(
+        ContinueDesignConversationRequestSchema,
+        "continueDesignConversationRequest"
+      ),
       response: {
-        200: zodToJsonSchema(ContinueDesignConversationResponseSchema, 'continueDesignConversationResponse')
-      }
+        200: zodToJsonSchema(
+          ContinueDesignConversationResponseSchema,
+          "continueDesignConversationResponse"
+        ),
+      },
     },
     handler: handleContinueDesignConversation,
   });
 
   // Generate image for game design
-  server.post('/conversation/generate-image', {
+  server.post("/conversation/generate-image", {
     schema: {
-      body: zodToJsonSchema(GenerateImageRequestSchema, 'generateImageRequest'),
+      body: zodToJsonSchema(GenerateImageRequestSchema, "generateImageRequest"),
       response: {
-        200: zodToJsonSchema(GenerateImageResponseSchema, 'generateImageResponse')
-      }
+        200: zodToJsonSchema(
+          GenerateImageResponseSchema,
+          "generateImageResponse"
+        ),
+      },
     },
     handler: handleGenerateImage,
   });
 
   // Get full specification
-  server.post('/conversation/specification', {
+  server.post("/conversation/specification", {
     schema: {
-      body: zodToJsonSchema(GetFullSpecificationRequestSchema, 'getFullSpecificationRequest'),
+      body: zodToJsonSchema(
+        GetFullSpecificationRequestSchema,
+        "getFullSpecificationRequest"
+      ),
       response: {
-        200: zodToJsonSchema(GetFullSpecificationResponseSchema, 'getFullSpecificationResponse')
-      }
+        200: zodToJsonSchema(
+          GetFullSpecificationResponseSchema,
+          "getFullSpecificationResponse"
+        ),
+      },
     },
     handler: handleGetFullSpecification,
+  });
+
+  // Get conversation history
+  server.post("/conversation/history", {
+    schema: {
+      body: zodToJsonSchema(
+        GetConversationHistoryRequestSchema,
+        "getConversationHistoryRequest"
+      ),
+      response: {
+        200: zodToJsonSchema(
+          GetConversationHistoryResponseSchema,
+          "getConversationHistoryResponse"
+        ),
+      },
+    },
+    handler: handleGetConversationHistory,
   });
 }

--- a/src/api/design/schemas.ts
+++ b/src/api/design/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 // Player count schema
 export const PlayerCountSchema = z.object({
@@ -48,13 +48,44 @@ export const GetFullSpecificationResponseSchema = z.object({
   designSpecification: z.string(),
 });
 
+// Get conversation history schemas
+export const GetConversationHistoryRequestSchema = z.object({
+  conversationId: z.string().min(1),
+});
+
+export const MessageSchema = z.object({
+  type: z.enum(["human", "ai", "system"]),
+  content: z.string(),
+  timestamp: z.string().optional(),
+});
+
+export const GetConversationHistoryResponseSchema = z.object({
+  conversationId: z.string(),
+  messages: z.array(MessageSchema),
+  totalMessages: z.number(),
+});
+
 // Type exports
 export type PlayerCount = z.infer<typeof PlayerCountSchema>;
 export type GameSpecification = z.infer<typeof GameSpecificationSchema>;
-export type ContinueDesignConversationRequest = z.infer<typeof ContinueDesignConversationRequestSchema>;
-export type ContinueDesignConversationResponse = z.infer<typeof ContinueDesignConversationResponseSchema>;
+export type ContinueDesignConversationRequest = z.infer<
+  typeof ContinueDesignConversationRequestSchema
+>;
+export type ContinueDesignConversationResponse = z.infer<
+  typeof ContinueDesignConversationResponseSchema
+>;
 export type GenerateImageRequest = z.infer<typeof GenerateImageRequestSchema>;
 export type GenerateImageResponse = z.infer<typeof GenerateImageResponseSchema>;
-export type GetFullSpecificationRequest = z.infer<typeof GetFullSpecificationRequestSchema>;
-export type GetFullSpecificationResponse = z.infer<typeof GetFullSpecificationResponseSchema>;
-
+export type GetFullSpecificationRequest = z.infer<
+  typeof GetFullSpecificationRequestSchema
+>;
+export type GetFullSpecificationResponse = z.infer<
+  typeof GetFullSpecificationResponseSchema
+>;
+export type GetConversationHistoryRequest = z.infer<
+  typeof GetConversationHistoryRequestSchema
+>;
+export type GetConversationHistoryResponse = z.infer<
+  typeof GetConversationHistoryResponseSchema
+>;
+export type Message = z.infer<typeof MessageSchema>;

--- a/src/api/design/schemas.ts
+++ b/src/api/design/schemas.ts
@@ -65,6 +65,15 @@ export const GetConversationHistoryResponseSchema = z.object({
   totalMessages: z.number(),
 });
 
+// Get conversation metadata schemas
+export const GetConversationMetadataRequestSchema = z.object({
+  conversationId: z.string().min(1),
+});
+
+export const GetConversationMetadataResponseSchema = z.object({
+  title: z.string(),
+});
+
 // Type exports
 export type PlayerCount = z.infer<typeof PlayerCountSchema>;
 export type GameSpecification = z.infer<typeof GameSpecificationSchema>;
@@ -87,5 +96,11 @@ export type GetConversationHistoryRequest = z.infer<
 >;
 export type GetConversationHistoryResponse = z.infer<
   typeof GetConversationHistoryResponseSchema
+>;
+export type GetConversationMetadataRequest = z.infer<
+  typeof GetConversationMetadataRequestSchema
+>;
+export type GetConversationMetadataResponse = z.infer<
+  typeof GetConversationMetadataResponseSchema
 >;
 export type Message = z.infer<typeof MessageSchema>;

--- a/src/api/design/schemas.ts
+++ b/src/api/design/schemas.ts
@@ -74,6 +74,20 @@ export const GetConversationMetadataResponseSchema = z.object({
   title: z.string(),
 });
 
+export const PublishGameRequestSchema = z.object({
+  conversationId: z.string().min(1),
+  gameTitle: z.string().min(1),
+  version: z.number().min(1).default(1),
+  imageUrl: z.string().optional(),
+  userId: z.string().min(1),
+});
+
+export const PublishGameResponseSchema = z.object({
+  ipfsHash: z.string(),
+  gameTitle: z.string(),
+  version: z.number(),
+});
+
 // Type exports
 export type PlayerCount = z.infer<typeof PlayerCountSchema>;
 export type GameSpecification = z.infer<typeof GameSpecificationSchema>;
@@ -104,3 +118,5 @@ export type GetConversationMetadataResponse = z.infer<
   typeof GetConversationMetadataResponseSchema
 >;
 export type Message = z.infer<typeof MessageSchema>;
+export type PublishGameRequest = z.infer<typeof PublishGameRequestSchema>;
+export type PublishGameResponse = z.infer<typeof PublishGameResponseSchema>;


### PR DESCRIPTION
New `POST /conversation/history` endpoint that returns clean conversation history for game design sessions.

**Features:**
- Filters out system prompts and internal messages
- Returns structured messages with type (human/ai), content, and timestamps
- Proper error handling for missing conversations
- Full type safety with Zod schemas

**Usage:**
```json
POST /conversation/history
{ "conversationId": "conversation-123" }
```

Perfect for displaying actual user-AI conversations in the UI without internal system noise.

