### PR TITLE
Continue Simulation API + design pagination and small cleanups

### DIFF
--- a/src/api/design/handler.ts
+++ b/src/api/design/handler.ts
@@ -133,8 +133,8 @@ export async function handleGetConversationHistory(
   }
 
   try {
-    const { conversationId } = result.data;
-    const history = await getConversationHistory(conversationId);
+    const { conversationId, page, limit } = result.data;
+    const history = await getConversationHistory(conversationId, page, limit);
 
     return history;
   } catch (error) {

--- a/src/api/design/schemas.ts
+++ b/src/api/design/schemas.ts
@@ -51,6 +51,8 @@ export const GetFullSpecificationResponseSchema = z.object({
 // Get conversation history schemas
 export const GetConversationHistoryRequestSchema = z.object({
   conversationId: z.string().min(1),
+  page: z.number().min(1).default(1),
+  limit: z.number().min(1).max(100).default(50),
 });
 
 export const MessageSchema = z.object({
@@ -63,6 +65,9 @@ export const GetConversationHistoryResponseSchema = z.object({
   conversationId: z.string(),
   messages: z.array(MessageSchema),
   totalMessages: z.number(),
+  page: z.number(),
+  limit: z.number(),
+  hasMore: z.boolean(),
 });
 
 // Get conversation metadata schemas

--- a/src/api/simulate/routes.ts
+++ b/src/api/simulate/routes.ts
@@ -1,11 +1,12 @@
-import { FastifyInstance } from 'fastify';
+import { FastifyInstance } from "fastify";
 import {
   handleCreateSimulation,
   handleInitializeSimulation,
   handleProcessAction,
   handleGetSimulationState,
   handleUpdateSimulation,
-} from './handler.js';
+  handleContinueSimulation,
+} from "./handler.js";
 import {
   CreateSimulationRequestSchema,
   CreateSimulationResponseSchema,
@@ -17,62 +18,108 @@ import {
   GetSimulationStateResponseSchema,
   UpdateSimulationRequestSchema,
   UpdateSimulationResponseSchema,
-} from '#chaincraft/api/simulate/schemas.js';
-import { zodToJsonSchema } from 'zod-to-json-schema';
+  ContinueSimulationRequestSchema,
+  ContinueSimulationResponseSchema,
+} from "#chaincraft/api/simulate/schemas.js";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 export async function registerSimulateRoutes(server: FastifyInstance) {
   // Create simulation
-  server.post('/create', {
+  server.post("/create", {
     schema: {
-      body: zodToJsonSchema(CreateSimulationRequestSchema, 'createSimulationRequest'),
+      body: zodToJsonSchema(
+        CreateSimulationRequestSchema,
+        "createSimulationRequest"
+      ),
       response: {
-        200: zodToJsonSchema(CreateSimulationResponseSchema, 'createSimulationResponse')
-      }
+        200: zodToJsonSchema(
+          CreateSimulationResponseSchema,
+          "createSimulationResponse"
+        ),
+      },
     },
     handler: handleCreateSimulation,
   });
 
   // Initialize simulation
-  server.post('/initialize', {
+  server.post("/initialize", {
     schema: {
-      body: zodToJsonSchema(InitializeSimulationRequestSchema, 'initializeSimulationRequest'),
+      body: zodToJsonSchema(
+        InitializeSimulationRequestSchema,
+        "initializeSimulationRequest"
+      ),
       response: {
-        200: zodToJsonSchema(InitializeSimulationResponseSchema, 'initializeSimulationResponse')
-      }
+        200: zodToJsonSchema(
+          InitializeSimulationResponseSchema,
+          "initializeSimulationResponse"
+        ),
+      },
     },
     handler: handleInitializeSimulation,
   });
 
   // Process action
-  server.post('/action', {
+  server.post("/action", {
     schema: {
-      body: zodToJsonSchema(ProcessActionRequestSchema, 'processActionRequest'),
+      body: zodToJsonSchema(ProcessActionRequestSchema, "processActionRequest"),
       response: {
-        200: zodToJsonSchema(ProcessActionResponseSchema, 'processActionResponse')
-      }
+        200: zodToJsonSchema(
+          ProcessActionResponseSchema,
+          "processActionResponse"
+        ),
+      },
     },
     handler: handleProcessAction,
   });
 
   // Get simulation state
-  server.post('/state', {
+  server.post("/state", {
     schema: {
-      body: zodToJsonSchema(GetSimulationStateRequestSchema, 'getSimulationStateRequest'),
+      body: zodToJsonSchema(
+        GetSimulationStateRequestSchema,
+        "getSimulationStateRequest"
+      ),
       response: {
-        200: zodToJsonSchema(GetSimulationStateResponseSchema, 'getSimulationStateResponse')
-      }
+        200: zodToJsonSchema(
+          GetSimulationStateResponseSchema,
+          "getSimulationStateResponse"
+        ),
+      },
     },
     handler: handleGetSimulationState,
   });
 
   // Update simulation
-  server.post('/update', {
+  server.post("/update", {
     schema: {
-      body: zodToJsonSchema(UpdateSimulationRequestSchema, 'updateSimulationRequest'),
+      body: zodToJsonSchema(
+        UpdateSimulationRequestSchema,
+        "updateSimulationRequest"
+      ),
       response: {
-        200: zodToJsonSchema(UpdateSimulationResponseSchema, 'updateSimulationResponse')
-      }
+        200: zodToJsonSchema(
+          UpdateSimulationResponseSchema,
+          "updateSimulationResponse"
+        ),
+      },
     },
     handler: handleUpdateSimulation,
+  });
+
+  // Continue simulation
+  server.post("/continue", {
+    schema: {
+      body: zodToJsonSchema(
+        ContinueSimulationRequestSchema,
+        "continueSimulationRequest"
+      ),
+      response: {
+        200: zodToJsonSchema(
+          ContinueSimulationResponseSchema,
+          "continueSimulationResponse"
+        ),
+      },
+    },
+    handler: handleContinueSimulation,
   });
 }

--- a/src/api/simulate/schemas.ts
+++ b/src/api/simulate/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 // Runtime player state schema
 export const RuntimePlayerStateSchema = z.object({
@@ -9,7 +9,10 @@ export const RuntimePlayerStateSchema = z.object({
 });
 
 // Player states schema (Map serialized as object)
-export const PlayerStatesSchema = z.record(z.string(), RuntimePlayerStateSchema);
+export const PlayerStatesSchema = z.record(
+  z.string(),
+  RuntimePlayerStateSchema
+);
 
 // Simulation response schema
 export const SimResponseSchema = z.object({
@@ -66,17 +69,46 @@ export const UpdateSimulationResponseSchema = z.object({
   success: z.boolean(),
 });
 
+// Continue simulation schemas
+export const ContinueSimulationRequestSchema = z.object({
+  gameId: z.string().min(1),
+});
+
+export const ContinueSimulationResponseSchema = SimResponseSchema;
+
 // Type exports
 export type RuntimePlayerState = z.infer<typeof RuntimePlayerStateSchema>;
 export type PlayerStates = z.infer<typeof PlayerStatesSchema>;
 export type SimResponse = z.infer<typeof SimResponseSchema>;
-export type CreateSimulationRequest = z.infer<typeof CreateSimulationRequestSchema>;
-export type CreateSimulationResponse = z.infer<typeof CreateSimulationResponseSchema>;
-export type InitializeSimulationRequest = z.infer<typeof InitializeSimulationRequestSchema>;
-export type InitializeSimulationResponse = z.infer<typeof InitializeSimulationResponseSchema>;
+export type CreateSimulationRequest = z.infer<
+  typeof CreateSimulationRequestSchema
+>;
+export type CreateSimulationResponse = z.infer<
+  typeof CreateSimulationResponseSchema
+>;
+export type InitializeSimulationRequest = z.infer<
+  typeof InitializeSimulationRequestSchema
+>;
+export type InitializeSimulationResponse = z.infer<
+  typeof InitializeSimulationResponseSchema
+>;
 export type ProcessActionRequest = z.infer<typeof ProcessActionRequestSchema>;
 export type ProcessActionResponse = z.infer<typeof ProcessActionResponseSchema>;
-export type GetSimulationStateRequest = z.infer<typeof GetSimulationStateRequestSchema>;
-export type GetSimulationStateResponse = z.infer<typeof GetSimulationStateResponseSchema>;
-export type UpdateSimulationRequest = z.infer<typeof UpdateSimulationRequestSchema>;
-export type UpdateSimulationResponse = z.infer<typeof UpdateSimulationResponseSchema>;
+export type GetSimulationStateRequest = z.infer<
+  typeof GetSimulationStateRequestSchema
+>;
+export type GetSimulationStateResponse = z.infer<
+  typeof GetSimulationStateResponseSchema
+>;
+export type UpdateSimulationRequest = z.infer<
+  typeof UpdateSimulationRequestSchema
+>;
+export type UpdateSimulationResponse = z.infer<
+  typeof UpdateSimulationResponseSchema
+>;
+export type ContinueSimulationRequest = z.infer<
+  typeof ContinueSimulationRequestSchema
+>;
+export type ContinueSimulationResponse = z.infer<
+  typeof ContinueSimulationResponseSchema
+>;


### PR DESCRIPTION
## Summary
-  Add POST `/simulate/continue` so the frontend can trigger “Continue Game” (Discord parity). Implements `continueSimulation` via `processAction`.
-  Add pagination to design conversation history (`page`, `limit`, `hasMore`) and fetch only the latest checkpoint for design/spec/history to reduce overhead.

## Changes
-  ai/simulate: Introduce `continueSimulation(gameId)` to advance games or prompt waiting players; safer defaults in `getSimResponse`.
-  api/simulate: Add handler, schema, and route for `POST /simulate/continue`; serialize `playerStates` Map to plain objects.
-  ai/design + api/design: Latest-checkpoint lookups; conversation history pagination.

## New endpoint
-  POST `/simulate/continue`
  - Request: `{ "gameId": "<string>" }`
  - Response: SimResponse (publicMessage, playerStates, gameEnded)

## Notes
-  No breaking changes; enables frontend to resume stalled games.